### PR TITLE
Add support for displaying an optional tag passed to the tracer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ pom.xml.asc
 .lein-failures
 .nrepl-port
 clairvoyant.iml
+/tags

--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,3 @@ pom.xml.asc
 .lein-failures
 .nrepl-port
 clairvoyant.iml
-/tags

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject gnl/re-frame-tracer "0.1.2-SNAPSHOT"
+(defproject gnl/re-frame-tracer "0.1.3-SNAPSHOT"
   :description "Tracer for clairvoyant that is optimised for cljs-devtools"
   :url "http://github.com/gnl/re-frame-tracer"
   :license {:name "MIT"}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject gnl/re-frame-tracer "0.1.1-SNAPSHOT"
+(defproject gnl/re-frame-tracer "0.1.2-SNAPSHOT"
   :description "Tracer for clairvoyant that is optimised for cljs-devtools"
   :url "http://github.com/gnl/re-frame-tracer"
   :license {:name "MIT"}

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(defproject gnl/re-frame-tracer "0.1.3-SNAPSHOT"
+(defproject day8/re-frame-tracer "0.1.3-SNAPSHOT"
   :description "Tracer for clairvoyant that is optimised for cljs-devtools"
-  :url "http://github.com/gnl/re-frame-tracer"
+  :url "http://github.com/day8/re-frame-tracer"
   :license {:name "MIT"}
 
   :dependencies

--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,10 @@
-(defproject day8/re-frame-tracer "0.1.0-SNAPSHOT"
+(defproject gnl/re-frame-tracer "0.1.1-SNAPSHOT"
   :description "Tracer for clairvoyant that is optimised for cljs-devtools"
-  :url "http://github.com/day8/re-frame-tracer"
+  :url "http://github.com/gnl/re-frame-tracer"
   :license {:name "MIT"}
 
   :dependencies
   [[org.clojure/clojure "1.6.0" :scope "provided"]
    [org.clojure/clojurescript "0.0-2322" :scope "provided"]
-   [org.clojars.stumitchell/clairvoyant "0.1.0-20150715.050527-4"]]
-)
+   [org.clojars.stumitchell/clairvoyant "0.1.0-20150715.050527-4"]])
+

--- a/src/re_frame_tracer/core.cljs
+++ b/src/re_frame_tracer/core.cljs
@@ -63,7 +63,7 @@
       (-trace-exit [_ {:keys [op exit]}]
                    (cond
                      (#{'binding} op)
-                     (do ;(log-exit exit)
+                     (do (log-exit exit)
                        (.groupEnd js/console))
 
                      (has-bindings? op)

--- a/src/re_frame_tracer/core.cljs
+++ b/src/re_frame_tracer/core.cljs
@@ -49,12 +49,12 @@
                              (when anonymous? " (anonymous)")))
                 arglist (remove '#{&} arglist)]
             (.groupCollapsed js/console "%c%s" (str "color:" color ";") title)
-            (.groupCollapsed js/console "bindings"))
+            (.group js/console "bindings"))
 
           (#{'let `let} op)
           (let [title (str op)]
             (.groupCollapsed js/console title)
-            (.groupCollapsed js/console "bindings"))
+            (.group js/console "bindings"))
 
           (#{'binding} op)
           (log-binding form init)))
@@ -63,7 +63,7 @@
       (-trace-exit [_ {:keys [op exit]}]
                    (cond
                      (#{'binding} op)
-                     (do (log-exit exit)
+                     (do ;(log-exit exit)
                        (.groupEnd js/console))
 
                      (has-bindings? op)


### PR DESCRIPTION
Dynamically named anonymous functions aren't always a feasible option. For example the recommended debugging workflow for re-frame conflicts with the usage of plumatic-schema-annotated functions (nested s/defn macros pased to the trace-forms macro), so this is an easy solution to add some additional information to a trace like p.ex. the handler/subscription name.
